### PR TITLE
Add protractor support

### DIFF
--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -49,20 +49,26 @@ var _ = require('lodash');
 
         var schedule = function() {
             var t0 = Date.now();
-
-            browser.takeScreenshot(function(error, screenshot) {
-                if (error) throw error;
-
-                if (!running) return;
-
-                var t1 = Date.now();
-                var dt = t1 - t0;
-                var delay = Math.max(0, frameInterval - dt);
-
-                timer = setTimeout(schedule, delay);
-
-                save(screenshot);
-            });
+            if(global['protractor'] !=null){
+                browser.takeScreenshot().then(function(screenshot) {
+                     if (!running) return;
+                    var t1 = Date.now();
+                    var dt = t1 - t0;
+                    var delay = Math.max(0, frameInterval - dt);                    
+                    timer = setTimeout(schedule, delay);
+                    save(screenshot);
+                });
+            }else{
+                browser.takeScreenshot(function(error, screenshot) {
+                    if (error) throw error;
+                    if (!running) return;
+                    var t1 = Date.now();
+                    var dt = t1 - t0;
+                    var delay = Math.max(0, frameInterval - dt);
+                    timer = setTimeout(schedule, delay);
+                    save(screenshot);
+                });
+            }
         };
 
         this.start = function() {


### PR DESCRIPTION
When environment is Protractor - "browser" variable  is wrapped instance around native WD browser. Like, most of methods are return promises and ignore callbacks arguments.
This make impossible to use wd-video-recorder under Protractor.

This PR adds Protractor support.
