### PR TITLE
Use browser.saveScreenshot's Promise

### DIFF
--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -50,19 +50,37 @@ var _ = require('lodash');
         var schedule = function() {
             var t0 = Date.now();
 
-            browser.takeScreenshot(function(error, screenshot) {
-                if (error) throw error;
+            
+            if(!!browser.saveScreenshot && !!browser.saveScreenshot.then){
+                browser.saveScreenshot().then(function(screenshot) {
+                    if (!running) return;
 
-                if (!running) return;
+                    var t1 = Date.now();
+                    var dt = t1 - t0;
+                    var delay = Math.max(0, frameInterval - dt);
 
-                var t1 = Date.now();
-                var dt = t1 - t0;
-                var delay = Math.max(0, frameInterval - dt);
+                    timer = setTimeout(schedule, delay);
 
-                timer = setTimeout(schedule, delay);
+                    save(screenshot);
+                }).catch(function(err){
+                    throw err;
+                });
+            }else{
+                browser.takeScreenshot(function(error, screenshot) {
+                    if (error) throw error;
 
-                save(screenshot);
-            });
+                    if (!running) return;
+
+                    var t1 = Date.now();
+                    var dt = t1 - t0;
+                    var delay = Math.max(0, frameInterval - dt);
+
+                    timer = setTimeout(schedule, delay);
+
+                    save(screenshot);
+                });
+
+            }
         };
 
         this.start = function() {


### PR DESCRIPTION
## Problem
The problem was that the function used to save a screenshot could be a function named `saveScreenshot` and that function could be be of type `Promise`. This change looks to see if that method is there and is indeed a Promise. 

## Solution 
If `browser.saveScreenshot` is defined and is a Promise, use that instead of `.takeScreenshot` 's callback
